### PR TITLE
Implement issue #3: Extend persistence layer with SQLite, relational game registrations, and board game cache

### DIFF
--- a/CcsHackathon/Data/ApplicationDbContext.cs
+++ b/CcsHackathon/Data/ApplicationDbContext.cs
@@ -8,5 +8,55 @@ public class ApplicationDbContext : DbContext
         : base(options)
     {
     }
+
+    public DbSet<Registration> Registrations { get; set; }
+    public DbSet<GameRegistration> GameRegistrations { get; set; }
+    public DbSet<BoardGameCache> BoardGameCaches { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // Configure Registration entity
+        modelBuilder.Entity<Registration>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.UserId).IsRequired();
+            entity.Property(e => e.UserDisplayName).IsRequired();
+            entity.Property(e => e.CreatedAt).IsRequired();
+        });
+
+        // Configure GameRegistration entity
+        modelBuilder.Entity<GameRegistration>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.GameId).IsRequired();
+
+            // Configure one-to-many relationship: Registration -> GameRegistration
+            entity.HasOne(e => e.Registration)
+                .WithMany(r => r.GameRegistrations)
+                .HasForeignKey(e => e.RegistrationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // Configure one-to-one relationship: GameRegistration -> BoardGameCache
+            entity.HasOne(e => e.BoardGameCache)
+                .WithOne(b => b.GameRegistration)
+                .HasForeignKey<BoardGameCache>(b => b.GameRegistrationId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // Configure BoardGameCache entity
+        modelBuilder.Entity<BoardGameCache>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.GameRegistrationId).IsRequired();
+            entity.Property(e => e.GameName).IsRequired();
+            entity.Property(e => e.LastUpdatedAt).IsRequired();
+
+            // Configure unique constraint on GameName
+            entity.HasIndex(e => e.GameName).IsUnique();
+        });
+    }
 }
+
 

--- a/CcsHackathon/Data/BoardGameCache.cs
+++ b/CcsHackathon/Data/BoardGameCache.cs
@@ -1,0 +1,15 @@
+namespace CcsHackathon.Data;
+
+public class BoardGameCache
+{
+    public Guid Id { get; set; }
+    public Guid GameRegistrationId { get; set; }
+    public string GameName { get; set; } = string.Empty;
+    public string? ExternalId { get; set; }
+    public string? RulesText { get; set; }
+    public DateTime LastUpdatedAt { get; set; }
+    
+    // Navigation property for one-to-one relationship with GameRegistration
+    public GameRegistration GameRegistration { get; set; } = null!;
+}
+

--- a/CcsHackathon/Data/GameRegistration.cs
+++ b/CcsHackathon/Data/GameRegistration.cs
@@ -1,0 +1,15 @@
+namespace CcsHackathon.Data;
+
+public class GameRegistration
+{
+    public Guid Id { get; set; }
+    public Guid RegistrationId { get; set; }
+    public string GameId { get; set; } = string.Empty;
+    
+    // Navigation property for many-to-one relationship with Registration
+    public Registration Registration { get; set; } = null!;
+    
+    // Navigation property for one-to-one relationship with BoardGameCache
+    public BoardGameCache? BoardGameCache { get; set; }
+}
+

--- a/CcsHackathon/Data/Registration.cs
+++ b/CcsHackathon/Data/Registration.cs
@@ -1,0 +1,13 @@
+namespace CcsHackathon.Data;
+
+public class Registration
+{
+    public Guid Id { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public string UserDisplayName { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    
+    // Navigation property for one-to-many relationship
+    public ICollection<GameRegistration> GameRegistrations { get; set; } = new List<GameRegistration>();
+}
+


### PR DESCRIPTION
Resolves #3

## Summary
This PR extends the persistence layer to support multi-game registrations per user and includes a caching mechanism for externally sourced board game data.

## Changes
- ✅ Created \Registration\ entity with Id, UserId, UserDisplayName, CreatedAt
- ✅ Created \GameRegistration\ entity with Id, RegistrationId, GameId
- ✅ Created \BoardGameCache\ entity with Id, GameName (unique), ExternalId, RulesText, LastUpdatedAt
- ✅ Configured one-to-many relationship: Registration → GameRegistration (with cascade delete)
- ✅ Configured one-to-one relationship: GameRegistration → BoardGameCache (with cascade delete)
- ✅ Updated \ApplicationDbContext\ with DbSets and Fluent API configuration
- ✅ Added unique index on \BoardGameCache.GameName\

## Database Schema
- **Registration**: Stores user registration information
- **GameRegistration**: Links games to registrations (supports multiple games per registration)
- **BoardGameCache**: Caches board game metadata with unique game names

## Testing
- ✅ Project builds successfully
- ✅ No linter errors
- ✅ Database schema will be created automatically on application startup