### PR TITLE
Implement issue #11: Background AI Agent

### DIFF
--- a/CcsHackathon/CcsHackathon.csproj
+++ b/CcsHackathon/CcsHackathon.csproj
@@ -5,9 +5,11 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <UserSecretsId>ccs-hackathon-secrets</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Betalgo.OpenAI" Version="7.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.1" />

--- a/CcsHackathon/Data/ApplicationDbContext.cs
+++ b/CcsHackathon/Data/ApplicationDbContext.cs
@@ -53,6 +53,9 @@ public class ApplicationDbContext : DbContext
             entity.Property(e => e.GameRegistrationId).IsRequired();
             entity.Property(e => e.GameName).IsRequired();
             entity.Property(e => e.LastUpdatedAt).IsRequired();
+            entity.Property(e => e.HasAiData).IsRequired();
+            entity.Property(e => e.Complexity).HasPrecision(5, 2);
+            entity.Property(e => e.TimeToSetupMinutes).IsRequired(false);
 
             // Configure unique constraint on GameName
             entity.HasIndex(e => e.GameName).IsUnique();

--- a/CcsHackathon/Data/BoardGameCache.cs
+++ b/CcsHackathon/Data/BoardGameCache.cs
@@ -9,6 +9,12 @@ public class BoardGameCache
     public string? RulesText { get; set; }
     public DateTime LastUpdatedAt { get; set; }
     
+    // AI-generated fields
+    public decimal? Complexity { get; set; }
+    public int? TimeToSetupMinutes { get; set; }
+    public string? Summary { get; set; }
+    public bool HasAiData { get; set; }
+    
     // Navigation property for one-to-one relationship with GameRegistration
     public GameRegistration GameRegistration { get; set; } = null!;
 }

--- a/CcsHackathon/Services/BoardGameAiBackgroundService.cs
+++ b/CcsHackathon/Services/BoardGameAiBackgroundService.cs
@@ -1,0 +1,202 @@
+using CcsHackathon.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace CcsHackathon.Services;
+
+public class BoardGameAiBackgroundService : BackgroundService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<BoardGameAiBackgroundService> _logger;
+    private readonly TimeSpan _processingInterval = TimeSpan.FromMinutes(5); // Process every 5 minutes
+    private readonly int _maxRetries = 3;
+    private readonly TimeSpan _retryDelay = TimeSpan.FromSeconds(30);
+
+    public BoardGameAiBackgroundService(
+        IServiceProvider serviceProvider,
+        ILogger<BoardGameAiBackgroundService> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Board Game AI Background Service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessGamesAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in Board Game AI Background Service execution loop");
+            }
+
+            // Wait before next processing cycle
+            await Task.Delay(_processingInterval, stoppingToken);
+        }
+
+        _logger.LogInformation("Board Game AI Background Service stopped");
+    }
+
+    private async Task ProcessGamesAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var aiService = scope.ServiceProvider.GetRequiredService<IBoardGameAiService>();
+
+        try
+        {
+            // Find games that need AI data
+            // Look for GameRegistrations where the game name doesn't have AI data yet
+            var gamesNeedingData = await dbContext.GameRegistrations
+                .Include(gr => gr.BoardGameCache)
+                .Where(gr => 
+                    gr.BoardGameCache == null || 
+                    !gr.BoardGameCache.HasAiData ||
+                    string.IsNullOrWhiteSpace(gr.BoardGameCache.Summary))
+                .Select(gr => new
+                {
+                    GameRegistrationId = gr.Id,
+                    GameName = gr.GameId,
+                    BoardGameCache = gr.BoardGameCache
+                })
+                .ToListAsync(cancellationToken);
+
+            if (!gamesNeedingData.Any())
+            {
+                _logger.LogDebug("No games need AI data processing");
+                return;
+            }
+
+            _logger.LogInformation("Found {Count} games needing AI data", gamesNeedingData.Count);
+
+            foreach (var game in gamesNeedingData)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                    break;
+
+                await ProcessGameAsync(dbContext, aiService, game.GameRegistrationId, game.GameName, game.BoardGameCache, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing games for AI data");
+        }
+    }
+
+    private async Task ProcessGameAsync(
+        ApplicationDbContext dbContext,
+        IBoardGameAiService aiService,
+        Guid gameRegistrationId,
+        string gameName,
+        BoardGameCache? existingCache,
+        CancellationToken cancellationToken)
+    {
+        // Idempotent check: if AI data already exists and is complete, skip
+        if (existingCache != null && existingCache.HasAiData && !string.IsNullOrWhiteSpace(existingCache.Summary))
+        {
+            _logger.LogDebug("Game {GameName} already has AI data, skipping", gameName);
+            return;
+        }
+
+        _logger.LogInformation("Processing AI data for game: {GameName}", gameName);
+
+        int attempt = 0;
+        BoardGameAiData? aiData = null;
+
+        // Retry logic
+        while (attempt < _maxRetries && aiData == null)
+        {
+            attempt++;
+            try
+            {
+                aiData = await aiService.GenerateAiDataAsync(gameName);
+                
+                if (aiData != null)
+                {
+                    break; // Success
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Attempt {Attempt} failed to generate AI data for game {GameName}", attempt, gameName);
+                
+                if (attempt < _maxRetries)
+                {
+                    await Task.Delay(_retryDelay, cancellationToken);
+                }
+            }
+        }
+
+        if (aiData == null)
+        {
+            _logger.LogError("Failed to generate AI data for game {GameName} after {Attempts} attempts", gameName, _maxRetries);
+            return;
+        }
+
+        try
+        {
+            // Update or create BoardGameCache
+            if (existingCache == null)
+            {
+                // Check if a cache exists by game name (unique constraint)
+                var existingByName = await dbContext.BoardGameCaches
+                    .FirstOrDefaultAsync(c => c.GameName == gameName, cancellationToken);
+
+                if (existingByName != null)
+                {
+                    // Update existing cache
+                    existingByName.Complexity = aiData.Complexity;
+                    existingByName.TimeToSetupMinutes = aiData.TimeToSetupMinutes;
+                    existingByName.Summary = aiData.Summary;
+                    existingByName.HasAiData = true;
+                    existingByName.LastUpdatedAt = DateTime.UtcNow;
+                    
+                    // Update the GameRegistration to point to this cache
+                    var gameReg = await dbContext.GameRegistrations
+                        .FirstOrDefaultAsync(gr => gr.Id == gameRegistrationId, cancellationToken);
+                    if (gameReg != null)
+                    {
+                        gameReg.BoardGameCache = existingByName;
+                    }
+                }
+                else
+                {
+                    // Create new cache
+                    var newCache = new BoardGameCache
+                    {
+                        Id = Guid.NewGuid(),
+                        GameRegistrationId = gameRegistrationId,
+                        GameName = gameName,
+                        Complexity = aiData.Complexity,
+                        TimeToSetupMinutes = aiData.TimeToSetupMinutes,
+                        Summary = aiData.Summary,
+                        HasAiData = true,
+                        LastUpdatedAt = DateTime.UtcNow
+                    };
+                    dbContext.BoardGameCaches.Add(newCache);
+                }
+            }
+            else
+            {
+                // Update existing cache
+                existingCache.Complexity = aiData.Complexity;
+                existingCache.TimeToSetupMinutes = aiData.TimeToSetupMinutes;
+                existingCache.Summary = aiData.Summary;
+                existingCache.HasAiData = true;
+                existingCache.LastUpdatedAt = DateTime.UtcNow;
+            }
+
+            await dbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("Successfully saved AI data for game: {GameName}", gameName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error saving AI data for game: {GameName}", gameName);
+        }
+    }
+}
+

--- a/CcsHackathon/Services/BoardGameAiService.cs
+++ b/CcsHackathon/Services/BoardGameAiService.cs
@@ -1,0 +1,124 @@
+using OpenAI;
+using OpenAI.Managers;
+using OpenAI.ObjectModels.RequestModels;
+using OpenAI.ObjectModels;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace CcsHackathon.Services;
+
+public class BoardGameAiService : IBoardGameAiService
+{
+    private readonly ILogger<BoardGameAiService> _logger;
+    private readonly string? _apiKey;
+    private readonly OpenAIService? _service;
+
+    public BoardGameAiService(IConfiguration configuration, ILogger<BoardGameAiService> logger)
+    {
+        _logger = logger;
+        _apiKey = configuration["OpenAI:ApiKey"];
+        
+        if (string.IsNullOrWhiteSpace(_apiKey))
+        {
+            _logger.LogWarning("OpenAI API key not configured. AI service will not function.");
+            _service = null;
+        }
+        else
+        {
+            _service = new OpenAIService(new OpenAiOptions
+            {
+                ApiKey = _apiKey
+            });
+        }
+    }
+
+    public async Task<BoardGameAiData?> GenerateAiDataAsync(string gameName)
+    {
+        if (_service == null)
+        {
+            _logger.LogWarning("OpenAI service not initialized. Skipping AI data generation for {GameName}", gameName);
+            return null;
+        }
+
+        try
+        {
+            _logger.LogInformation("Generating AI data for board game: {GameName}", gameName);
+
+            var prompt = $@"Analyze the board game ""{gameName}"" and provide the following information in JSON format:
+{{
+  ""complexity"": <a decimal number from 1.0 to 5.0 representing game complexity, where 1.0 is very simple and 5.0 is very complex>,
+  ""timeToSetupMinutes"": <an integer representing the estimated time in minutes to set up the game>,
+  ""summary"": ""<a brief 2-3 sentence summary of the game, its mechanics, and what makes it interesting>""
+}}
+
+Only return valid JSON, no additional text or markdown formatting.";
+
+            var messages = new List<ChatMessage>
+            {
+                ChatMessage.FromSystem("You are a board game expert. Provide accurate, concise information about board games in JSON format."),
+                ChatMessage.FromUser(prompt)
+            };
+
+            var completionResult = await _service.ChatCompletion.CreateCompletion(new ChatCompletionCreateRequest
+            {
+                Messages = messages,
+                Model = Models.Gpt_3_5_Turbo,
+                Temperature = 0.3f,
+                MaxTokens = 500
+            });
+
+            if (!completionResult.Successful)
+            {
+                _logger.LogWarning("OpenAI API call failed for game {GameName}: {Error}", gameName, completionResult.Error?.Message);
+                return null;
+            }
+
+            var content = completionResult.Choices.FirstOrDefault()?.Message?.Content?.Trim();
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                _logger.LogWarning("Empty response from OpenAI for game: {GameName}", gameName);
+                return null;
+            }
+
+            // Clean up the response - remove markdown code blocks if present
+            content = Regex.Replace(content, @"^```json\s*", "", RegexOptions.Multiline);
+            content = Regex.Replace(content, @"^```\s*$", "", RegexOptions.Multiline);
+            content = content.Trim();
+
+            var aiData = JsonSerializer.Deserialize<BoardGameAiData>(content, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            if (aiData == null)
+            {
+                _logger.LogWarning("Failed to parse AI response for game: {GameName}. Response: {Response}", gameName, content);
+                return null;
+            }
+
+            // Validate the data
+            if (aiData.Complexity < 1.0m || aiData.Complexity > 5.0m)
+            {
+                _logger.LogWarning("Invalid complexity value {Complexity} for game {GameName}. Clamping to valid range.", aiData.Complexity, gameName);
+                aiData.Complexity = Math.Clamp(aiData.Complexity, 1.0m, 5.0m);
+            }
+
+            if (aiData.TimeToSetupMinutes < 0)
+            {
+                _logger.LogWarning("Invalid time to setup {Time} for game {GameName}. Setting to 0.", aiData.TimeToSetupMinutes, gameName);
+                aiData.TimeToSetupMinutes = 0;
+            }
+
+            _logger.LogInformation("Successfully generated AI data for game: {GameName}. Complexity: {Complexity}, Setup Time: {Time}min", 
+                gameName, aiData.Complexity, aiData.TimeToSetupMinutes);
+
+            return aiData;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error generating AI data for game: {GameName}", gameName);
+            return null;
+        }
+    }
+}

--- a/CcsHackathon/Services/IBoardGameAiService.cs
+++ b/CcsHackathon/Services/IBoardGameAiService.cs
@@ -1,0 +1,16 @@
+using CcsHackathon.Data;
+
+namespace CcsHackathon.Services;
+
+public interface IBoardGameAiService
+{
+    Task<BoardGameAiData?> GenerateAiDataAsync(string gameName);
+}
+
+public class BoardGameAiData
+{
+    public decimal Complexity { get; set; }
+    public int TimeToSetupMinutes { get; set; }
+    public string Summary { get; set; } = string.Empty;
+}
+

--- a/CcsHackathon/appsettings.Development.json
+++ b/CcsHackathon/appsettings.Development.json
@@ -7,5 +7,8 @@
   },
   "Features": {
     "UseDummyAuth": true
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }

--- a/CcsHackathon/appsettings.json
+++ b/CcsHackathon/appsettings.json
@@ -23,5 +23,8 @@
   "MicrosoftGraph": {
     "BaseUrl": "https://graph.microsoft.com/v1.0",
     "Scopes": "User.Read.All"
+  },
+  "OpenAI": {
+    "ApiKey": ""
   }
 }


### PR DESCRIPTION
- **Implement issue #11: Background AI Agent to retrieve and score board game data**
- Extend BoardGameCache entity with AI-generated fields (Complexity, TimeToSetupMinutes, Summary, HasAiData)
- Create IBoardGameAiService and BoardGameAiService for ChatGPT integration
- Implement BoardGameAiBackgroundService (IHostedService) to process games in background
- Add retry logic and error handling for AI API calls
- Implement idempotent checks to avoid regenerating existing AI data
- Add OpenAI configuration to appsettings
- Update database initialization to detect schema changes and recreate when needed
- Add UserSecretsId to project file for user secrets support
- Add comprehensive logging for monitoring success/failure