### PR TITLE
Display number of attending players on session overviews (#44)

### DIFF
--- a/CcsHackathon/Components/Pages/SessionManagement.razor
+++ b/CcsHackathon/Components/Pages/SessionManagement.razor
@@ -97,7 +97,87 @@
         </div>
     </div>
     
-    @if (editingSession != null)
+    <div class="row mt-4">
+        <div class="col-12">
+            <h3>Upcoming Sessions</h3>
+            @if (upcomingSessionsWithCounts == null)
+            {
+                <p>Loading upcoming sessions...</p>
+            }
+            else if (!upcomingSessionsWithCounts.Any())
+            {
+                <p class="text-muted">No upcoming sessions.</p>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover">
+                        <thead>
+                            <tr>
+                                <th>Session Date</th>
+                                <th>Number of Attendees</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var sessionWithCount in upcomingSessionsWithCounts)
+                            {
+                                <tr>
+                                    <td class="align-middle">
+                                        <strong>@sessionWithCount.Session.Date.ToString("yyyy-MM-dd")</strong>
+                                    </td>
+                                    <td class="align-middle">
+                                        @sessionWithCount.AttendeeCount
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    </div>
+    
+    <div class="row mt-4">
+        <div class="col-12">
+            <h3>Historic Sessions</h3>
+            @if (historicSessionsWithCounts == null)
+            {
+                <p>Loading historic sessions...</p>
+            }
+            else if (!historicSessionsWithCounts.Any())
+            {
+                <p class="text-muted">No historic sessions.</p>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-striped table-hover">
+                        <thead>
+                            <tr>
+                                <th>Session Date</th>
+                                <th>Number of Attendees</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var sessionWithCount in historicSessionsWithCounts)
+                            {
+                                <tr>
+                                    <td class="align-middle">
+                                        <strong>@sessionWithCount.Session.Date.ToString("yyyy-MM-dd")</strong>
+                                    </td>
+                                    <td class="align-middle">
+                                        @sessionWithCount.AttendeeCount
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        </div>
+    </div>
+    
+    @if (editingSession != null && editSessionModel != null)
     {
         <div class="modal fade show d-block" style="background-color: rgba(0,0,0,0.5);" tabindex="-1">
             <div class="modal-dialog">
@@ -120,7 +200,7 @@
                                 <label for="editSessionDate" class="form-label">New Date</label>
                                 <InputDate TValue="DateOnly" id="editSessionDate" class="form-control" 
                                            Value="editSessionModel.Date" 
-                                           ValueChanged="@((DateOnly value) => editSessionModel.Date = value)"
+                                           ValueChanged="@((DateOnly value) => editSessionModel!.Date = value)"
                                            ValueExpression="@(() => editSessionModel.Date)" />
                                 <ValidationMessage For="@(() => editSessionModel.Date)" />
                             </div>
@@ -148,6 +228,8 @@
     private SessionModel? editSessionModel;
     private Session? editingSession;
     private List<Session>? sessions;
+    private List<SessionWithAttendeeCount>? upcomingSessionsWithCounts;
+    private List<SessionWithAttendeeCount>? historicSessionsWithCounts;
     private string createMessage = string.Empty;
     private bool isCreateError = false;
     private bool isCreating = false;
@@ -156,6 +238,7 @@
     protected override async Task OnInitializedAsync()
     {
         await LoadSessionsAsync();
+        await LoadSessionsWithCountsAsync();
     }
 
     private async Task LoadSessionsAsync()
@@ -168,6 +251,21 @@
         {
             Logger.LogError(ex, "Error loading sessions");
             sessions = new List<Session>();
+        }
+    }
+
+    private async Task LoadSessionsWithCountsAsync()
+    {
+        try
+        {
+            upcomingSessionsWithCounts = (await SessionService.GetUpcomingSessionsWithAttendeeCountAsync()).ToList();
+            historicSessionsWithCounts = (await SessionService.GetHistoricSessionsWithAttendeeCountAsync()).ToList();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading sessions with attendee counts");
+            upcomingSessionsWithCounts = new List<SessionWithAttendeeCount>();
+            historicSessionsWithCounts = new List<SessionWithAttendeeCount>();
         }
     }
 
@@ -184,6 +282,7 @@
             createMessage = "Session created successfully!";
             sessionModel = new SessionModel();
             await LoadSessionsAsync();
+            await LoadSessionsWithCountsAsync();
         }
         catch (Exception ex)
         {
@@ -224,6 +323,7 @@
             editingSession = null;
             editSessionModel = null;
             await LoadSessionsAsync();
+            await LoadSessionsWithCountsAsync();
         }
         catch (Exception ex)
         {
@@ -241,6 +341,7 @@
         {
             await SessionService.CancelSessionAsync(sessionId);
             await LoadSessionsAsync();
+            await LoadSessionsWithCountsAsync();
         }
         catch (Exception ex)
         {

--- a/CcsHackathon/Services/ISessionService.cs
+++ b/CcsHackathon/Services/ISessionService.cs
@@ -6,8 +6,18 @@ public interface ISessionService
 {
     Task<Session> CreateSessionAsync(DateOnly date);
     Task<IEnumerable<Session>> GetAllSessionsAsync();
+    Task<IEnumerable<Session>> GetUpcomingSessionsAsync();
+    Task<IEnumerable<Session>> GetHistoricSessionsAsync();
+    Task<IEnumerable<SessionWithAttendeeCount>> GetUpcomingSessionsWithAttendeeCountAsync();
+    Task<IEnumerable<SessionWithAttendeeCount>> GetHistoricSessionsWithAttendeeCountAsync();
     Task<Session?> GetSessionByIdAsync(Guid sessionId);
     Task<Session> UpdateSessionDateAsync(Guid sessionId, DateOnly newDate);
     Task CancelSessionAsync(Guid sessionId);
+}
+
+public class SessionWithAttendeeCount
+{
+    public Session Session { get; set; } = null!;
+    public int AttendeeCount { get; set; }
 }
 


### PR DESCRIPTION
## Description

This PR resolves issue #44 by adding attendee counts to both upcoming and historic session overviews.

## Changes

- Added `GetHistoricSessionsAsync` method to `ISessionService` and `SessionService`
- Added `GetUpcomingSessionsWithAttendeeCountAsync` and `GetHistoricSessionsWithAttendeeCountAsync` methods that efficiently count unique users per session
- Updated `SessionManagement.razor` to display separate tables for upcoming and historic sessions
- Added 'Number of Attendees' column to both session overview tables
- Used efficient aggregate queries (`COUNT(DISTINCT UserId)`) to avoid N+1 query issues

## Technical Details

- Server-side aggregation using Entity Framework Core
- Single query per session list (upcoming/historic) to get all attendee counts
- No performance degradation when loading session lists

## Acceptance Criteria Met

 Future sessions overview displays attendee count
 Historic sessions overview displays attendee count  
 Counts are accurate and reflect unique users
 No performance degradation when loading session lists
