### PR TITLE
Hide Login and Dashboard from menu, redirect to Register Game

### DIFF
--- a/CcsHackathon/Components/Layout/NavMenu.razor
+++ b/CcsHackathon/Components/Layout/NavMenu.razor
@@ -8,7 +8,8 @@
 
 <div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
     <nav class="nav flex-column">
-        <div class="nav-item px-3">
+        @* Login and Dashboard pages hidden from menu but code remains intact *@
+        @*<div class="nav-item px-3">
             <NavLink class="nav-link" href="login">
                 <span class="bi bi-box-arrow-in-right-nav-menu" aria-hidden="true"></span> Login
             </NavLink>
@@ -18,7 +19,7 @@
             <NavLink class="nav-link" href="dashboard">
                 <span class="bi bi-speedometer2-nav-menu" aria-hidden="true"></span> Dashboard
             </NavLink>
-        </div>
+        </div>*@
 
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="register-game">

--- a/CcsHackathon/Components/Pages/Redirect.razor
+++ b/CcsHackathon/Components/Pages/Redirect.razor
@@ -7,15 +7,8 @@
 @code {
     protected override void OnInitialized()
     {
-        // Redirect based on authentication status
-        if (UserContext.IsAuthenticated)
-        {
-            Navigation.NavigateTo("/register-game", forceLoad: true);
-        }
-        else
-        {
-            Navigation.NavigateTo("/login", forceLoad: true);
-        }
+        // Always redirect to register game page (login and dashboard hidden from menu)
+        Navigation.NavigateTo("/register-game", forceLoad: true);
     }
 }
 


### PR DESCRIPTION
## Description

This PR hides the Login and Dashboard pages from the navigation menu and updates the default route to land on the Register Game page.

## Changes

- **Navigation Menu:**
  - Commented out Login and Dashboard navigation links
  - Code remains intact (commented with Razor syntax) for future use
  - Added comment explaining the pages are hidden but code remains

- **Default Route:**
  - Updated `Redirect.razor` to always redirect to `/register-game`
  - Removed authentication check that previously redirected to `/login`
  - Users now land on Register Game page by default

## Technical Details

- Login and Dashboard pages are still accessible via direct URL if needed
- All underlying code remains intact
- No functionality removed, only UI visibility changed
